### PR TITLE
Changed function paths and tag names to accomodate modern Django versions

### DIFF
--- a/experiments/admin.py
+++ b/experiments/admin.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.http import JsonResponse, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.utils import timezone
 

--- a/experiments/migrations/0001_initial.py
+++ b/experiments/migrations/0001_initial.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+import django.db.models.deletion
 import django.utils.timezone
 import jsonfield.fields
 from django.conf import settings
+from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
@@ -31,20 +31,22 @@ class Migration(migrations.Migration):
                 ('alternatives', jsonfield.fields.JSONField(default={}, blank=True)),
                 ('relevant_chi2_goals', models.TextField(default=b'', null=True, blank=True)),
                 ('relevant_mwu_goals', models.TextField(default=b'', null=True, blank=True)),
-                ('state', models.IntegerField(default=0, choices=[(0, b'Default/Control'), (1, b'Enabled'), (3, b'Track')])),
-                ('start_date', models.DateTimeField(default=django.utils.timezone.now, null=True, db_index=True, blank=True)),
+                ('state',
+                 models.IntegerField(default=0, choices=[(0, b'Default/Control'), (1, b'Enabled'), (3, b'Track')])),
+                ('start_date',
+                 models.DateTimeField(default=django.utils.timezone.now, null=True, db_index=True, blank=True)),
                 ('end_date', models.DateTimeField(null=True, blank=True)),
             ],
         ),
         migrations.AddField(
             model_name='enrollment',
             name='experiment',
-            field=models.ForeignKey(to='experiments.Experiment'),
+            field=models.ForeignKey(to='experiments.Experiment', on_delete=django.db.models.deletion.DO_NOTHING),
         ),
         migrations.AddField(
             model_name='enrollment',
             name='user',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.DO_NOTHING),
         ),
         migrations.AlterUniqueTogether(
             name='enrollment',

--- a/experiments/models.py
+++ b/experiments/models.py
@@ -1,15 +1,14 @@
-from django.db import models
-from django.core.serializers.json import DjangoJSONEncoder
-from django.conf import settings
+import json
+import random
 
+import django.db.models.deletion
+from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db import models
 from jsonfield import JSONField
 
-import random
-import json
-
-from experiments.dateutils import now
 from experiments import conf
-
+from experiments.dateutils import now
 
 CONTROL_STATE = 0
 ENABLED_STATE = 1
@@ -106,8 +105,9 @@ class Experiment(models.Model):
 
 class Enrollment(models.Model):
     """ A participant in a split testing experiment """
-    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'))
-    experiment = models.ForeignKey(Experiment)
+    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
+                             on_delete=django.db.models.deletion.DO_NOTHING)
+    experiment = models.ForeignKey(Experiment, on_delete=django.db.models.deletion.DO_NOTHING)
     enrollment_date = models.DateTimeField(auto_now_add=True)
     last_seen = models.DateTimeField(null=True)
     alternative = models.CharField(max_length=50)
@@ -127,5 +127,3 @@ def weighted_choice(choices):
         upto += w
         if upto >= r:
             return c
-
-

--- a/experiments/templatetags/experiments.py
+++ b/experiments/templatetags/experiments.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django import template
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from experiments.utils import participant
 from experiments.manager import experiment_manager
@@ -101,7 +101,7 @@ def experiment(parser, token):
     return ExperimentNode(node_list, experiment_name, alternative, weight, user_variable)
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def experiment_enroll(context, experiment_name, *alternatives, **kwargs):
     if 'user' in kwargs:
         user = participant(user=kwargs['user'])


### PR DESCRIPTION
In order to use django-experiments in modern Django I changed some calls and function invocations to fit deprecations and code-reorganisations made in Django > 2.2

This PR contains fixes which appears to have made django-experiments suitable for Django 3.0.7